### PR TITLE
Override _vpc_security_group_ids

### DIFF
--- a/terrafomo-gen/config/aws/r/db_instance.yaml
+++ b/terrafomo-gen/config/aws/r/db_instance.yaml
@@ -1,0 +1,3 @@
+arguments:
+  _vpc_security_group_ids:
+    type: '[TF.Attr s P.Text]'


### PR DESCRIPTION
Baby's first override - putting `_vpc_security_group_ids` in line with the one used in `instance`.