### PR TITLE
Distribute Connected Types into Separate Namespaces via Bin Packing

### DIFF
--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -247,6 +247,7 @@ language_extensions:
   - RankNTypes
   - ScopedTypeVariables
   - StandaloneDeriving
+  - TemplateHaskell
   - TupleSections
   - TypeApplications
   - TypeFamilies

--- a/terrafomo-gen/config/aws.yaml
+++ b/terrafomo-gen/config/aws.yaml
@@ -1,6 +1,8 @@
 package-name: terrafomo-aws
 provider-name: AWS
 
+bin-capacity: 60
+
 extra-deps:
   - amazonka-core
   - formatting

--- a/terrafomo-gen/config/aws.yaml
+++ b/terrafomo-gen/config/aws.yaml
@@ -1,8 +1,6 @@
 package-name: terrafomo-aws
 provider-name: AWS
 
-bin-capacity: 60
-
 extra-deps:
   - amazonka-core
   - formatting

--- a/terrafomo-gen/package.yaml
+++ b/terrafomo-gen/package.yaml
@@ -36,7 +36,6 @@ executables:
       - mtl
       - optparse-applicative
       - pretty-show
-      - split
       - text
       - unordered-containers
       - word-wrap

--- a/terrafomo-gen/src/Main.hs
+++ b/terrafomo-gen/src/Main.hs
@@ -106,12 +106,17 @@ main = do
 --                    , primitivesTemplate = "primitives.ede"
                     }
 
-        config@Config'{configPackageYAML, configBinCapacity} <-
-            parseYAML "Config" (configYAML opts)
+        config@Config'
+            { configPackageYAML
+            , configTypesBinCapacity
+            , configLensesBinCapacity
+            } <- parseYAML "Config" (configYAML opts)
 
-        provider@Provider'{providerName, providerOriginal} <-
-            parseJSON "Provider" (providerJSON opts)
-                >>= hoistEither . Elab.run config
+        provider@Provider'
+            { providerName
+            , providerOriginal
+            } <- parseJSON "Provider" (providerJSON opts)
+                     >>= hoistEither . Elab.run config
 
         let providerDir = "provider"  </> Text.unpack (providerPackage provider)
             genDir      = providerDir </> "gen"
@@ -122,18 +127,18 @@ main = do
             typesFile   = srcDir      </> NS.toPath (NS.types providerName) <.> "hs"
 
             lenses      =
-                Partition.lenses provider
+                Partition.lenses configLensesBinCapacity provider
 
             resources   =
-                Partition.schemas configBinCapacity providerName "Resource"
+                Partition.schemas configTypesBinCapacity providerName "Resource"
                     resourceSchema (providerResources provider)
 
             datasources =
-                Partition.schemas configBinCapacity providerName "DataSource"
+                Partition.schemas configTypesBinCapacity providerName "DataSource"
                     resourceSchema (providerDataSources provider)
 
             settings    =
-                Partition.schemas configBinCapacity providerName "Settings"
+                Partition.schemas configTypesBinCapacity providerName "Settings"
                     fromSettings (providerSettings provider)
 
             renderContents name ns namespaces =

--- a/terrafomo-gen/src/Terrafomo/Gen/Config.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/Config.hs
@@ -13,21 +13,23 @@ import qualified Data.Set           as Set
 import qualified Terrafomo.Gen.JSON as JSON
 
 data Config = Config'
-    { configPackage      :: !Text
-    , configPackageYAML  :: !Bool
-    , configProviderName :: !ProviderName
-    , configBinCapacity  :: !Int
-    , configDependencies :: !(Set Text)
-    , configOverrides    :: !(Map DataName (Map VarName Text))
+    { configPackage           :: !Text
+    , configPackageYAML       :: !Bool
+    , configProviderName      :: !ProviderName
+    , configTypesBinCapacity  :: !Int
+    , configLensesBinCapacity :: !Int
+    , configDependencies      :: !(Set Text)
+    , configOverrides         :: !(Map DataName (Map VarName Text))
     } deriving (Show, Eq)
 
 instance JSON.FromJSON Config where
     parseJSON = JSON.withObject "Config" $ \o -> do
-        configPackage      <- o .:  "package-name"
-        configPackageYAML  <- o .:? "package-yaml"    .!= True
-        configProviderName <- o .:  "provider-name"
-        configBinCapacity  <- o .:? "bin-capacity"    .!= 100
-        configOverrides    <- o .:? "field-overrides" .!= mempty
+        configPackage           <- o .:  "package-name"
+        configPackageYAML       <- o .:? "package-yaml"        .!= True
+        configProviderName      <- o .:  "provider-name"
+        configTypesBinCapacity  <- o .:? "types-bin-capacity"  .!= 80
+        configLensesBinCapacity <- o .:? "lenses-bin-capacity" .!= 800
+        configOverrides         <- o .:? "field-overrides"     .!= mempty
 
         configDependencies  <-
             mappend dependencies

--- a/terrafomo-gen/src/Terrafomo/Gen/Config.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/Config.hs
@@ -13,21 +13,21 @@ import qualified Data.Set           as Set
 import qualified Terrafomo.Gen.JSON as JSON
 
 data Config = Config'
-    { configPackage       :: !Text
-    , configPackageYAML   :: !Bool
-    , configProviderName  :: !ProviderName
-    , configPartitionSize :: !Int
-    , configDependencies  :: !(Set Text)
-    , configOverrides     :: !(Map DataName (Map VarName Text))
+    { configPackage      :: !Text
+    , configPackageYAML  :: !Bool
+    , configProviderName :: !ProviderName
+    , configBinCapacity  :: !Int
+    , configDependencies :: !(Set Text)
+    , configOverrides    :: !(Map DataName (Map VarName Text))
     } deriving (Show, Eq)
 
 instance JSON.FromJSON Config where
     parseJSON = JSON.withObject "Config" $ \o -> do
-        configPackage       <- o .:  "package-name"
-        configPackageYAML   <- o .:? "package-yaml"    .!= True
-        configProviderName  <- o .:  "provider-name"
-        configPartitionSize <- o .:? "partition-size"  .!= 100
-        configOverrides     <- o .:? "field-overrides" .!= mempty
+        configPackage      <- o .:  "package-name"
+        configPackageYAML  <- o .:? "package-yaml"    .!= True
+        configProviderName <- o .:  "provider-name"
+        configBinCapacity  <- o .:? "bin-capacity"    .!= 100
+        configOverrides    <- o .:? "field-overrides" .!= mempty
 
         configDependencies  <-
             mappend dependencies

--- a/terrafomo-gen/src/Terrafomo/Gen/Elab.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/Elab.hs
@@ -2,7 +2,6 @@
 
 module Terrafomo.Gen.Elab
     ( run
-    , classes
     ) where
 
 import Control.Applicative        ((<|>))
@@ -93,25 +92,6 @@ run cfg provider =
                    , providerPrimitives   = map fst (Map.elems _primitives)
                    , providerSchema       = schema
                    }
-
-classes :: Provider -> (Set Class, Set Class)
-classes p = (lenses, getters)
-  where
-    lenses  = Set.fromList (map go args)
-    getters = Set.fromList (map go attrs)
-
-    go x =
-        Class' { className   = fieldClass  x
-               , classMethod = fieldMethod x
-               }
-
-    args =  concatMap schemaArguments  schemas
-    attrs = concatMap schemaAttributes schemas
-
-    schemas =
-           map resourceSchema (providerResources   p)
-        ++ map resourceSchema (providerDataSources p)
-        ++ map fromSettings   (providerSchema p : providerSettings p)
 
 elabResource :: Text -> Text -> [Go.Schema] -> Elab Resource
 elabResource provider original schemas =

--- a/terrafomo-gen/src/Terrafomo/Gen/Graph.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/Graph.hs
@@ -1,0 +1,59 @@
+module Terrafomo.Gen.Graph
+    ( Graph
+    , new
+    , partition
+    , binpack
+    ) where
+
+import Prelude hiding (rem)
+
+import qualified Data.Foldable as Fold
+import qualified Data.Graph    as Graph
+import qualified Data.Tree     as Tree
+
+data Graph a = Graph
+    { graph :: !Graph.Graph
+    -- ^ The raw array based adjancency list.
+    , node  :: !(Graph.Vertex -> a)
+    -- ^ Returns the node associated with the given vertex.
+    }
+
+new :: Ord k
+    => (v -> k)    -- ^ Extract the node key.
+    -> (v -> [k])  -- ^ Extract the node dependencies.
+    -> [v]
+    -> Graph v
+new key deps xs =
+    let (g, f, _) = Graph.graphFromEdges (map (\x -> (x, key x, deps x)) xs)
+     in Graph { graph = g
+              , node  = \v -> let (x, _, _) = f v in x
+              }
+
+-- | Get the connected components of the graph and pack them into bins
+-- using the specified capacity.
+partition
+    :: Int -- ^ The capacity of a bin.
+    -> Graph a
+    -> [[a]]
+partition c g =
+      map (map (node g) . concat)
+    . binpack c length
+    . map Tree.flatten
+    $ Graph.components (graph g)
+
+-- | Bin-packing using online Next Fit.
+binpack
+    :: Int        -- ^ The capacity of a bin.
+    -> (a -> Int) -- ^ The weight (consumed capacity) of an item.
+    -> [a]
+    -> [[a]]
+binpack c weight xs =
+    filter (not . null) (y : ys)
+  where
+    (_, y, ys) = Fold.foldr' go (c, [], []) xs
+
+    go x (!rem, bin, bins)
+        | w > rem   = (c   - w, [x],     bin : bins)
+        | otherwise = (rem - w, x : bin, bins)
+      where
+        w = weight x

--- a/terrafomo-gen/src/Terrafomo/Gen/Haskell.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/Haskell.hs
@@ -11,7 +11,6 @@ import GHC.Generics (Generic)
 
 import Terrafomo.Gen.JSON ((.=))
 import Terrafomo.Gen.Name
-import Terrafomo.Gen.NS   (NS)
 import Terrafomo.Gen.Type (Type)
 
 import qualified Data.Foldable                    as Fold
@@ -25,7 +24,6 @@ import qualified Data.Text.Lazy.Builder.Int       as Build
 import qualified Data.Text.Lazy.Builder.RealFloat as Build
 import qualified Terrafomo.Gen.Graph              as Graph
 import qualified Terrafomo.Gen.JSON               as JSON
-import qualified Terrafomo.Gen.NS                 as NS
 import qualified Terrafomo.Gen.Text               as Text
 import qualified Terrafomo.Gen.Type               as Type
 import qualified Text.Wrap                        as Wrap
@@ -144,21 +142,9 @@ schemaConflicts = filter (not . Set.null . fieldConflicts) . schemaArguments
 
 schemaDependencies :: Schema a -> [DataName]
 schemaDependencies x =
-    let go = concatMap (Fold.toList . fieldType)
-     in go (schemaArguments  x)
-     ++ go (schemaAttributes x)
-
-partitionSchemas
-    :: Int
-    -> ProviderName
-    -> String
-    -> (a -> Schema Conflict)
-    -> [a]
-    -> [(NS, [a])]
-partitionSchemas c provider name f =
-    NS.assign provider name
-        . Graph.partition c
-        . Graph.new (schemaName . f) (schemaDependencies . f)
+        let go = concatMap (Fold.toList . fieldType)
+         in go (schemaArguments  x)
+         ++ go (schemaAttributes x)
 
 data Field a = Field'
     { fieldName      :: !LabelName
@@ -279,8 +265,9 @@ instance JSON.ToJSON Default where
         build = LText.toStrict . Build.toLazyText
 
 data Class = Class'
-    { className   :: !DataName
-    , classMethod :: !VarName
+    { className     :: !DataName
+    , classMethod   :: !VarName
+    , classComputed :: !Bool
     } deriving (Show, Eq, Ord, Generic)
 
 instance JSON.ToJSON Class where

--- a/terrafomo-gen/src/Terrafomo/Gen/Haskell.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/Haskell.hs
@@ -22,7 +22,6 @@ import qualified Data.Text.Lazy                   as LText
 import qualified Data.Text.Lazy.Builder           as Build
 import qualified Data.Text.Lazy.Builder.Int       as Build
 import qualified Data.Text.Lazy.Builder.RealFloat as Build
-import qualified Terrafomo.Gen.Graph              as Graph
 import qualified Terrafomo.Gen.JSON               as JSON
 import qualified Terrafomo.Gen.Text               as Text
 import qualified Terrafomo.Gen.Type               as Type

--- a/terrafomo-gen/src/Terrafomo/Gen/NS.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/NS.hs
@@ -1,4 +1,4 @@
-module Terrafomo.Gen.Namespace where
+module Terrafomo.Gen.NS where
 
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Semigroup     (Semigroup ((<>)))
@@ -12,7 +12,6 @@ import Text.Printf (printf)
 
 import qualified Data.Aeson.Types as JSON
 import qualified Data.Foldable    as Fold
-import qualified Data.List.Split  as Split
 import qualified Data.Set         as Set
 import qualified Data.Text        as Text
 
@@ -54,25 +53,18 @@ toPath = fromNS '/'
 
 -- Package Namespaces
 
-contents, provider, types, lenses, primitives, settings :: ProviderName -> NS
-contents   p = "Terrafomo" <> NS (pure (fromName p))
-provider   p = contents p  <> "Provider"
-types      p = contents p  <> "Types"
-lenses     p = contents p  <> "Lens"
-primitives p = contents p  <> "Primitives"
-settings   p = contents p  <> "Settings"
+contents, provider, datasources, resources, settings, primitives, types, lenses
+  :: ProviderName -> NS
+contents    p = "Terrafomo" <> NS (pure (fromName p))
+provider    p = contents p  <> "Provider"
+datasources p = contents p  <> "DataSources"
+resources   p = contents p  <> "Resources"
+settings    p = contents p  <> "Settings"
+primitives  p = contents p  <> "Primitives"
+types       p = contents p  <> "Types"
+lenses      p = contents p  <> "Lens"
 
-partition :: Int -> ProviderName -> String -> [b] -> [(NS, [b])]
-partition maxlen p root xs
-    | null   xs           = []
-    | length xs <= maxlen = [single]
-    | otherwise           =
-        zipWith multiple [1..]
-            . filter (not . null)
-                $ Split.chunksOf maxlen xs
+assign :: ProviderName -> String -> [a] -> [(NS, a)]
+assign (contents -> ns) name = zipWith go [1 :: Int ..]
   where
-    single =
-        (contents p <> fromString root, xs)
-
-    multiple (n :: Int) ys =
-        (contents p <> fromString (root ++ printf "%02d" n), ys)
+    go n x = (ns <> fromString (printf "%s%02d" name n), x)

--- a/terrafomo-gen/src/Terrafomo/Gen/NS.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/NS.hs
@@ -53,8 +53,14 @@ toPath = fromNS '/'
 
 -- Package Namespaces
 
-contents, provider, datasources, resources, settings, primitives, types, lenses
-  :: ProviderName -> NS
+contents
+  , provider
+  , datasources
+  , resources
+  , settings
+  , primitives
+  , types
+  , lenses :: ProviderName -> NS
 contents    p = "Terrafomo" <> NS (pure (fromName p))
 provider    p = contents p  <> "Provider"
 datasources p = contents p  <> "DataSources"

--- a/terrafomo-gen/src/Terrafomo/Gen/Name.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/Name.hs
@@ -1,8 +1,5 @@
 module Terrafomo.Gen.Name where
 
-import Control.Applicative ((<|>))
-
-import Data.Maybe     (fromMaybe)
 import Data.Semigroup (Semigroup ((<>)))
 import Data.Text      (Text)
 

--- a/terrafomo-gen/src/Terrafomo/Gen/Partition.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/Partition.hs
@@ -10,30 +10,33 @@ import Terrafomo.Gen.Haskell
 import Terrafomo.Gen.Name    (ProviderName)
 import Terrafomo.Gen.NS      (NS)
 
+import qualified Data.List           as List
 import qualified Data.Set            as Set
 import qualified Terrafomo.Gen.Graph as Graph
 import qualified Terrafomo.Gen.NS    as NS
 
 lenses
-    :: Provider
+    :: Int
+    -> Provider
     -> [(NS, (Set Class, Set Class))]
-lenses p = arguments ++ attributes
+lenses c p = arguments ++ attributes
   where
     name = providerName p
 
     arguments =
        map (second ((,mempty) . Set.fromList))
            . NS.assign name "Arguments"
-           . Graph.partition 1500
+           . Graph.partition c
            . Graph.new className (const [])
-           $ map (mk False) (concatMap schemaArguments xs)
+           $ List.nub (map (mk False) (concatMap schemaArguments xs))
 
+    -- Attribute classes are considerably less intensive to compile.
     attributes =
        map (second ((mempty,) . Set.fromList))
            . NS.assign name "Attributes"
-           . Graph.partition 1500
+           . Graph.partition (c * 3)
            . Graph.new className (const [])
-           $ map (mk True) (concatMap schemaAttributes xs)
+           $ List.nub (map (mk True) (concatMap schemaAttributes xs))
 
     mk b x = Class'
         { className     = fieldClass  x

--- a/terrafomo-gen/src/Terrafomo/Gen/Partition.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/Partition.hs
@@ -1,0 +1,58 @@
+module Terrafomo.Gen.Partition
+    ( lenses
+    , schemas
+    ) where
+
+import Data.Bifunctor (second)
+import Data.Set       (Set)
+
+import Terrafomo.Gen.Haskell
+import Terrafomo.Gen.Name    (ProviderName)
+import Terrafomo.Gen.NS      (NS)
+
+import qualified Data.Set            as Set
+import qualified Terrafomo.Gen.Graph as Graph
+import qualified Terrafomo.Gen.NS    as NS
+
+lenses
+    :: Provider
+    -> [(NS, (Set Class, Set Class))]
+lenses p = arguments ++ attributes
+  where
+    name = providerName p
+
+    arguments =
+       map (second ((,mempty) . Set.fromList))
+           . NS.assign name "Arguments"
+           . Graph.partition 1500
+           . Graph.new className (const [])
+           $ map (mk False) (concatMap schemaArguments xs)
+
+    attributes =
+       map (second ((mempty,) . Set.fromList))
+           . NS.assign name "Attributes"
+           . Graph.partition 1500
+           . Graph.new className (const [])
+           $ map (mk True) (concatMap schemaAttributes xs)
+
+    mk b x = Class'
+        { className     = fieldClass  x
+        , classMethod   = fieldMethod x
+        , classComputed = b
+        }
+
+    xs = map resourceSchema (providerResources   p)
+      ++ map resourceSchema (providerDataSources p)
+      ++ map fromSettings   (providerSchema p : providerSettings p)
+
+schemas
+    :: Int
+    -> ProviderName
+    -> String
+    -> (a -> Schema Conflict)
+    -> [a]
+    -> [(NS, [a])]
+schemas c provider name f =
+      NS.assign provider name
+    . Graph.partition c
+    . Graph.new (schemaName . f) (schemaDependencies . f)

--- a/terrafomo-gen/src/Terrafomo/Gen/Render.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/Render.hs
@@ -7,28 +7,29 @@ import Data.Semigroup ((<>))
 import Data.Text      (Text)
 
 import Terrafomo.Gen.Haskell
-import Terrafomo.Gen.Name      (ProviderName)
-import Terrafomo.Gen.Namespace (NS)
+import Terrafomo.Gen.NS   (NS)
+import Terrafomo.Gen.Name (ProviderName)
 
 import Text.EDE.Filters ((@:))
 
-import qualified Data.Aeson.Types        as JSON
-import qualified Data.HashMap.Strict     as HashMap
-import qualified Data.Set                as Set
-import qualified Data.Text               as Text
-import qualified Data.Text.Lazy          as LText
-import qualified Terrafomo.Gen.Namespace as NS
-import qualified Text.EDE                as EDE
+import qualified Data.Aeson.Types    as JSON
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Set            as Set
+import qualified Data.Text           as Text
+import qualified Data.Text.Lazy      as LText
+import qualified Terrafomo.Gen.NS    as NS
+import qualified Text.EDE            as EDE
 
 data Templates a = Templates
-    { packageTemplate    :: !a
-    , providerTemplate   :: !a
-    , resourceTemplate   :: !a
-    , contentsTemplate   :: !a
-    , typesTemplate      :: !a
-    , lensTemplate       :: !a
+    { packageTemplate  :: !a -- ^ Package YAML
+    , preludeTemplate  :: !a -- ^ Top-level export everything
+    , providerTemplate :: !a -- ^ Provider type
+    , contentsTemplate :: !a -- ^ Re-export of {DataSource,Resource,Settings}0..N
+    , resourceTemplate :: !a -- ^ DataSource/Resource types
+    , settingsTemplate :: !a -- ^ Settings types
+    , typesTemplate    :: !a -- ^ Skeleton src/*/Types.hs
+    , lensTemplate     :: !a -- ^ Overloaded lens classes
 --    , primitivesTemplate :: !a
-    , settingsTemplate   :: !a
     } deriving (Show, Functor, Foldable, Traversable)
 
 package
@@ -36,74 +37,57 @@ package
     -> Provider
     -> Either String LText.Text
 package tmpls p =
-    render (packageTemplate tmpls)
+    let name = providerName p
+     in render (packageTemplate tmpls)
         [ "package"      .= providerPackage      p
         , "dependencies" .= providerDependencies p
         , "exposed"      .=
             Set.fromList
-                [ NS.contents (providerName p)
+                [ NS.contents    name
+                , NS.provider    name
+                , NS.datasources name
+                , NS.resources   name
+                , NS.settings    name
+                , NS.lenses      name
+                , NS.types       name
                 ]
         ]
 
-contents
+prelude
     :: Templates EDE.Template
     -> ProviderName
-    -> [NS]
-    -> [NS]
     -> Either String (NS, LText.Text)
-contents tmpls p rs ds =
+prelude tmpls p =
     let ns = NS.contents p
-     in second (ns,) $ render (contentsTemplate tmpls)
+     in second (ns,) $ render (preludeTemplate tmpls)
         [ "namespace"   .= ns
-        , "provider"    .= NS.provider p
-        , "types"       .= NS.types    p
-        , "settings"    .= NS.settings p
-        , "lenses"      .= NS.lenses   p
-        , "datasources" .= ds
-        , "resources"   .= rs
-        ]
-
-types
-    :: Templates EDE.Template
-    -> ProviderName
-    -> Either String (NS, LText.Text)
-types tmpls p =
-    let ns = NS.types p
-     in second (ns,) $ render (typesTemplate tmpls)
-        [ "namespace"   .= ns
-        , "unqualified" .= [NS.lenses p]
+        , "provider"    .= NS.provider    p
+        , "datasources" .= NS.datasources p
+        , "resources"   .= NS.resources   p
+        , "settings"    .= NS.settings    p
+        , "lenses"      .= NS.lenses      p
+        , "types"       .= NS.types       p
         ]
 
 provider
     :: Templates EDE.Template
     -> Provider
-    -> [NS]
     -> Either String (NS, LText.Text)
-provider tmpls p namespaces =
+provider tmpls p =
     let name = providerName p
         ns   = NS.provider name
      in second (ns,) $ render (providerTemplate tmpls)
         [ "namespace"   .= ns
         , "provider"    .= p
-        , "unqualified" .= Set.fromList namespaces -- (NS.primitives name : namespaces)
+        , "unqualified" .=
+            (Set.fromList
+                [ NS.settings name
+                ])
         , "qualified"   .=
             (Set.fromList
                 [ NS.lenses name
                 , NS.types  name
                 ] <> NS.prelude)
-        ]
-
-lenses
-    :: Templates EDE.Template
-    -> ProviderName
-    -> (Set Class, Set Class)
-    -> Either String (NS, LText.Text)
-lenses tmpls p (args, attrs) =
-    let ns = NS.lenses p
-     in second (ns,) $ render (lensTemplate tmpls)
-        [ "namespace"        .= ns
-        , "argumentClasses"  .= args
-        , "attributeClasses" .= attrs
         ]
 
 -- primitives
@@ -121,6 +105,48 @@ lenses tmpls p (args, attrs) =
 --                 [ NS.types p
 --                 ] <> NS.prelude)
 --         ]
+
+contents
+    :: Templates EDE.Template
+    -> Text
+    -> NS
+    -> [NS]
+    -> Either String LText.Text
+contents tmpls heading ns namespaces =
+   render (contentsTemplate tmpls)
+        [ "namespace" .= ns
+        , "heading"   .= heading
+        , "exports"   .= namespaces
+        ]
+
+resources
+    :: Templates EDE.Template
+    -> ProviderName
+    -> Text
+    -> (Set Class, Set Class)
+    -> NS
+    -> [Resource]
+    -> Either String LText.Text
+resources tmpls p typ (args, attrs) ns xs =
+    render (resourceTemplate tmpls)
+        [ "namespace"        .= ns
+        , "provider"         .= p
+        , "type"             .= typ
+        , "resources"        .= xs
+        , "argumentClasses"  .= args
+        , "attributeClasses" .= attrs
+        , "unqualified"      .=
+            (Set.fromList
+                [ NS.settings p
+                ])
+        , "qualified"        .=
+            (Set.fromList
+                [ NS.lenses     p
+--                , NS.primitives p
+                , NS.provider   p
+                , NS.types      p
+                ] <> NS.prelude)
+        ]
 
 settings
     :: Templates EDE.Template
@@ -140,31 +166,28 @@ settings tmpls p ns xs =
                 ] <> NS.prelude)
         ]
 
-resources
+types
+    :: Templates EDE.Template
+    -> ProviderName
+    -> Either String (NS, LText.Text)
+types tmpls p =
+    let ns = NS.types p
+     in second (ns,) $ render (typesTemplate tmpls)
+        [ "namespace"   .= ns
+        , "unqualified" .= [NS.lenses p]
+        ]
+
+lenses
     :: Templates EDE.Template
     -> ProviderName
     -> (Set Class, Set Class)
-    -> [NS]
-    -> NS
-    -> Text
-    -> [Resource]
-    -> Either String LText.Text
-resources tmpls p (args, attrs) namespaces ns typ xs =
-    render (resourceTemplate tmpls)
+    -> Either String (NS, LText.Text)
+lenses tmpls p (args, attrs) =
+    let ns = NS.lenses p
+     in second (ns,) $ render (lensTemplate tmpls)
         [ "namespace"        .= ns
-        , "provider"         .= p
-        , "type"             .= typ
-        , "resources"        .= xs
         , "argumentClasses"  .= args
         , "attributeClasses" .= attrs
-        , "unqualified"      .= Set.fromList namespaces
-        , "qualified"        .=
-            (Set.fromList
-                [ NS.lenses     p
---                , NS.primitives p
-                , NS.provider   p
-                , NS.types      p
-                ] <> NS.prelude)
         ]
 
 render :: EDE.Template -> [JSON.Pair] -> Either String LText.Text

--- a/terrafomo-gen/src/Terrafomo/Gen/Type.hs
+++ b/terrafomo-gen/src/Terrafomo/Gen/Type.hs
@@ -13,12 +13,14 @@ import qualified Terrafomo.Gen.Go   as Go
 import qualified Terrafomo.Gen.JSON as JSON
 import qualified Terrafomo.Gen.Text as Text
 
-data Type
+data TypeF a
     = Free !Text
-    | Data !Bool !DataName
-    | Attr !Type
-    | App  !Type !Type
-      deriving (Show, Eq, Ord)
+    | Data !Bool !a
+    | Attr !(TypeF a)
+    | App  !(TypeF a) !(TypeF a)
+      deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
+
+type Type = TypeF DataName
 
 instance JSON.ToJSON Type where
     toJSON = JSON.String . typeName . reduce

--- a/terrafomo-gen/template/contents.ede
+++ b/terrafomo-gen/template/contents.ede
@@ -1,42 +1,15 @@
 -- This module is auto-generated.
 
-{-# OPTIONS_GHC -fno-warn-unused-imports #-}
-{-# OPTIONS_GHC -fno-warn-dodgy-exports  #-}
-
 {% include "_include/license.ede" %}
 --
 module {{ namespace }}
     (
-    -- * Provider Datatype
-      module {{ provider }}
-
-    -- * Custom Types
-    , module {{ types }}
-
-    -- * DataSources
-  {% for export in datasources %}
-    , module {{ export.value }}
-  {% endfor %}
-
-    -- * Resources
-  {% for export in resources %}
-    , module {{ export.value }}
-  {% endfor %}
-
-    -- * Settings
-    , module {{ settings }}
-
-    -- * Overloaded Lenses
-    , module {{ lenses }}
+    -- * {{ heading }}
+    {% for export in exports %}
+    {% if export.first %}  {% else %}, {% endif %}module {{ export.value }}
+    {% endfor %}
     ) where
 
-import {{ provider }}
-import {{ types }}
-{% for export in datasources %}
+{% for export in exports %}
 import {{ export.value }}
 {% endfor %}
-{% for export in resources %}
-import {{ export.value }}
-{% endfor %}
-import {{ settings }}
-import {{ lenses }}

--- a/terrafomo-gen/template/lenses.ede
+++ b/terrafomo-gen/template/lenses.ede
@@ -7,23 +7,25 @@
 --
 module {{ namespace }}
     (
-    -- * Overloaded Fields
+{% if !(arguments | empty) %}
     -- ** Arguments
-  {% for class in argumentClasses %}
+  {% for class in arguments %}
     {% if class.first %}  {% else %}, {% endif %}{{ class.value.name }} (..)
   {% endfor %}
-
-    -- ** Computed Attributes
-  {% for class in attributeClasses %}
-    , {{ class.value.name }} (..)
+{% elif !(attributes | empty) %}
+    -- ** Attributes
+  {% for class in attributes %}
+    {% if class.first %}  {% else %}, {% endif %}{{ class.value.name }} (..)
   {% endfor %}
+{% endif %}
     ) where
-
+{% for class in arguments %}
+  {% if class.first %}
 import GHC.Base ((.))
 
 import qualified Lens.Micro as P
 import qualified Terrafomo.Schema as TF
-{% for class in argumentClasses %}
+  {% endif %}
 
 class {{ class.value.name }} a b | a -> b where
     {{ class.value.method }} :: P.Lens' a b
@@ -31,7 +33,7 @@ class {{ class.value.name }} a b | a -> b where
 instance {{ class.value.name }} a b => {{ class.value.name }} (TF.Schema l p a) b where
     {{ class.value.method }} = TF.configuration . {{ class.value.method }}
 {% endfor %}
-{% for class in attributeClasses %}
+{% for class in attributes %}
 
 class {{ class.value.name }} a b | a -> b where
     {{ class.value.method }} :: a -> b

--- a/terrafomo-gen/template/prelude.ede
+++ b/terrafomo-gen/template/prelude.ede
@@ -1,0 +1,34 @@
+-- This module is auto-generated.
+
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
+{-# OPTIONS_GHC -fno-warn-dodgy-exports  #-}
+
+{% include "_include/license.ede" %}
+--
+module {{ namespace }}
+    (
+    -- * Provider
+      module {{ provider }}
+
+    -- * Types
+    , module {{ types }}
+
+    -- * Resources
+    , module {{ resources }}
+
+    -- * DataSources
+    , module {{ datasources }}
+
+    -- * Settings
+    , module {{ settings }}
+
+    -- * Overloaded Lenses
+    , module {{ lenses }}
+    ) where
+
+import {{ provider }}
+import {{ types }}
+import {{ resources }}
+import {{ datasources }}
+import {{ settings }}
+import {{ lenses }}


### PR DESCRIPTION
Adds a naive next fit bin-packing algorithm to place a type and it's connected components into module namespaces. The implementation is naive in the sense that the property of overfilling a bin is actually desirable.

Under the `types-bin-capacity: 80` and `lenses-bin-capacity: 800`, `terrafomo-aws` is generated as follows:

```
provider/terrafomo-aws/gen
└── Terrafomo
    ├── AWS
    │   ├── Arguments01.hs
    │   ├── Arguments02.hs
    │   ├── Arguments03.hs
    │   ├── Attributes01.hs
    │   ├── DataSource01.hs
    │   ├── DataSource02.hs
    │   ├── DataSources.hs
    │   ├── Lens.hs
    │   ├── Provider.hs
    │   ├── Resource01.hs
    │   ├── Resource02.hs
    │   ├── Resource03.hs
    │   ├── Resource04.hs
    │   ├── Resource05.hs
    │   ├── Resource06.hs
    │   ├── Resources.hs
    │   ├── Settings01.hs
    │   ├── Settings02.hs
    │   ├── Settings03.hs
    │   ├── Settings04.hs
    │   ├── Settings05.hs
    │   └── Settings.hs
    └── AWS.hs
```

The interspersed modules without ordinal suffixes are table-of-contents re-exports and exist to avoid having to do the dependency analysis between _all_ settings types, lenses, and resource/datasources. They are exposed in the `package.yaml` because Haddock can't handle the current `AWS.hs` top-level re-export everything approach. Since the ordinal suffixed modules are not exported, the Haddock should be reasonably browsable/discoverable.

The vague handwavy result is that around 1G memory is used and the overall compilation doesn't (via :eyes:) take more observable time, but overall should be an improvement for CI.

See:

* https://github.com/brendanhay/terrafomo/blob/eefb64f6d68aa58d228e8ddd4e6d72ab390cf2bf/terrafomo-gen/src/Terrafomo/Gen/Graph.hs
* https://github.com/brendanhay/terrafomo/blob/eefb64f6d68aa58d228e8ddd4e6d72ab390cf2bf/terrafomo-gen/src/Terrafomo/Gen/Partition.hs