### PR TITLE
Update define to reference provider alias correctly

### DIFF
--- a/terrafomo/package.yaml
+++ b/terrafomo/package.yaml
@@ -57,6 +57,7 @@ tests:
     dependencies:
       - hspec
       - hspec-discover
+      - microlens
       - prettyprinter
       - terrafomo
       - text

--- a/terrafomo/package.yaml
+++ b/terrafomo/package.yaml
@@ -57,5 +57,7 @@ tests:
     dependencies:
       - hspec
       - hspec-discover
+      - prettyprinter
       - terrafomo
       - text
+      - QuickCheck

--- a/terrafomo/src/Terrafomo/HCL.hs
+++ b/terrafomo/src/Terrafomo/HCL.hs
@@ -157,8 +157,8 @@ data Value
     -- ^ Lists of primitive types can be made with square brackets ([]). Example:
     -- ["foo", "bar", "baz"].
     | Map     !(Map Text Value)
-    -- ^ Maps can be made with braces ({}) and colons (:): { "foo": "bar",
-    -- "bar": "baz" }. Quotes may be omitted on keys, unless the key starts
+    -- ^ Maps can be made with braces ({}) and equals (=): { "foo"= "bar",
+    -- "bar"= "baz" }. Quotes may be omitted on keys, unless the key starts
     -- with a number, in which case quotes are required. Commas are required
     -- between key/value pairs for single line maps. A newline between
     -- key/value pairs is sufficient in multi-line maps.
@@ -180,7 +180,7 @@ instance Pretty Value where
         Bool    False           -> "false"
         List    xs              -> PP.nest 2 (PP.list (map pretty xs))
         Map     m               ->
-            let go (k, v) = PP.dquotes (pretty k) <> ": " <> pretty v
+            let go (k, v) = PP.dquotes (pretty k) <> "= " <> pretty v
              in prettyMap . PP.punctuate "," . map go $ Map.toList m
         Block   xs              -> prettyMap (map pretty xs)
 

--- a/terrafomo/src/Terrafomo/Monad.hs
+++ b/terrafomo/src/Terrafomo/Monad.hs
@@ -305,7 +305,7 @@ define name x@Schema{_schemaProvider, _schemaConfig, _schemaValidator} =
         alias <- insertProvider _schemaProvider
 
         let value = HCL.toSection $
-                        x { _schemaProvider = keyName <$> alias
+                        x { _schemaProvider = alias
                           , _schemaKeywords =
                               _schemaKeywords x
                                   <> pure (HCL.type_ typ)

--- a/terrafomo/src/Terrafomo/Schema.hs
+++ b/terrafomo/src/Terrafomo/Schema.hs
@@ -59,7 +59,7 @@ instance HasLifecycle (Schema (Lifecycle a) p a) a where
 
 instance ( HCL.IsObject l
          , HCL.IsObject a
-         ) => HCL.IsSection (Schema l Name a) where
+         ) => HCL.IsSection (Schema l Key a) where
     toSection Schema{..} =
         let k :| ks = _schemaKeywords
             common  = catMaybes

--- a/terrafomo/test/Terrafomo/HCLSpec.hs
+++ b/terrafomo/test/Terrafomo/HCLSpec.hs
@@ -1,6 +1,6 @@
-module HCLSpec (spec) where
+module Terrafomo.HCLSpec (spec) where
 
-import HCL
+import Terrafomo.HCL
 
 import Test.Hspec
 import Test.QuickCheck (property, (===))

--- a/terrafomo/test/Terrafomo/ProviderSpec.hs
+++ b/terrafomo/test/Terrafomo/ProviderSpec.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Terrafomo.ProviderSpec (spec) where
+
+import Data.Maybe      (catMaybes)
+import Data.Text       (Text)
+import Lens.Micro      ((&))
+import Test.Hspec
+import Test.QuickCheck ((===))
+
+import qualified Lens.Micro          as Lens
+import qualified Terrafomo.Attribute as TF
+import qualified Terrafomo.HCL       as TF
+import qualified Terrafomo.Lifecycle as TF
+import qualified Terrafomo.Name      as TF
+import qualified Terrafomo.Provider  as TF
+import qualified Terrafomo.Schema    as TF
+import qualified Terrafomo.Validator as TF
+
+
+data Provider = Provider'
+    { _testField :: Text
+    } deriving (Show, Eq, Ord)
+
+instance TF.IsProvider Provider where
+    type ProviderType Provider = "providertype"
+
+instance TF.IsObject Provider where
+    toObject Provider'{..} =
+        [ TF.assign "test_field" _testField
+        ]
+
+data TestResource s = TestResource'
+  { _testField :: TF.Attr s Text
+  } deriving (Show, Eq, Ord)
+
+testResource
+  :: TF.Attr s Text
+  -> TF.Schema (TF.Lifecycle (TestResource s)) (TF.Key) (TestResource s)
+testResource _testField =
+    TF.unsafeResource "test" TF.validator $
+        TestResource'
+            { _testField = _testField
+            }
+
+instance TF.IsValid (TestResource s) where
+    validator = mempty
+
+instance TF.IsObject (TestResource s) where
+    toObject TestResource'{..} = catMaybes
+        [ TF.assign "test_field" <$> TF.attribute _testField
+        ]
+
+
+spec :: Spec
+spec = do
+    describe "provider alias" $ do
+      it "should render provider name and alias separated by a period." $
+        let hash     = TF.Name "HashedProvider"
+            new      = Provider' "some_field"
+            key      = TF.providerKey new hash
+            resource =
+                testResource (TF.value "hi")
+                    & Lens.set TF.provider (Just key)
+        in
+            TF.renderDocument
+                 [ TF.toSection $ TF.providerSection (Just $ TF.keyName key) new
+                 , TF.toSection resource
+                 ]
+                 === "provider \"providertype\" {\n\
+                     \  alias = \"HashedProvider\"\n\
+                     \  test_field = \"some_field\"\n\
+                     \}\n\
+                     \\n\
+                     \resource {\n\
+                     \  test_field = \"hi\"\n\
+                     \  provider = \"providertype.HashedProvider\"\n\
+                     \}"


### PR DESCRIPTION
https://www.terraform.io/docs/configuration/providers.html#multiple-provider-instances

```
The value of the provider argument is always the provider name and an alias separated by a period, such as "aws.west" above.
```